### PR TITLE
fix memory opcodes

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -253,7 +253,7 @@ const parseIType = (
     immediate: immediateString,
   } = parsedSchema;
 
-  const opcode = ITYPE_OPCODES[name] || MEMORY_OPCODES[name];
+  const opcode = ITYPE_OPCODES[name] ?? MEMORY_OPCODES[name];
 
   const isBranch = Object.keys(BRANCH_OPCODES).includes(name);
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -253,7 +253,7 @@ const parseIType = (
     immediate: immediateString,
   } = parsedSchema;
 
-  const opcode = ITYPE_OPCODES[name];
+  const opcode = ITYPE_OPCODES[name] || MEMORY_OPCODES[name];
 
   const isBranch = Object.keys(BRANCH_OPCODES).includes(name);
 


### PR DESCRIPTION
Die opcodes von allen memory-Befehlen wurden nicht angezeigt, weil die nicht bei `ITYPE_OPCODES` dabei waren.
