### PR TITLE
fix wrong rs and rt register with i type instructions

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -269,8 +269,8 @@ const parseIType = (
     isBranch ? branchOffset : parseIntMaybeHex(immediateString),
     16
   );
-  var rt = REGISTER_MAP[rtString] ?? 0;
-  var rs = REGISTER_MAP[rsString] ?? 0;
+  let rt = REGISTER_MAP[rtString] ?? 0;
+  let rs = REGISTER_MAP[rsString] ?? 0;
   if (!isBranch && !isMemory) [rs, rt] = [rt, rs];
 
   return {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -256,6 +256,7 @@ const parseIType = (
   const opcode = ITYPE_OPCODES[name];
 
   const isBranch = Object.keys(BRANCH_OPCODES).includes(name);
+  const isMemory = Object.keys(MEMORY_OPCODES).includes(name);
 
   // If it's a branch instruction, calculate the branch offset
   const branchOffset =
@@ -268,9 +269,9 @@ const parseIType = (
     isBranch ? branchOffset : parseIntMaybeHex(immediateString),
     16
   );
-
-  const rt = REGISTER_MAP[rtString] ?? 0;
-  const rs = REGISTER_MAP[rsString] ?? 0;
+  var rt = REGISTER_MAP[rtString] ?? 0;
+  var rs = REGISTER_MAP[rsString] ?? 0;
+  if (!isBranch && !isMemory) [rs, rt] = [rt, rs];
 
   return {
     type: 'I' as const,


### PR DESCRIPTION
noch einer:
Bei manchen I-Typ Befehlen waren die rt- und rs-Register vertauscht. Z. B. steht in der Green Card für addi `R[rt] = R[rs] + SignExtImm`, d.h. das erste Register (das, das geändert wird) ist rt. Aber bei `addi $t0, $t1, 2` kommt rt = 9 (= $t1) raus.
Hab extra in Mars nachgeschaut und da ist es genauso. Schau vllt. nochmal drüber, ob wirklich alle Befehle abgedeckt sind.